### PR TITLE
Bd webplot  and rsimplot_rpathviz review

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,8 @@ Imports:
     grDevices,
     igraph,
     colorspace,
-    magrittr
+    magrittr,
+    stats
 Suggests: 
     knitr,
     rmarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,11 @@
 Package: rpathviz
-Title: What the Package Does (One Line, Title Case)
+Title: Beautiful plots for Ecopath/Rpath package
 Version: 0.0.0.9000
 Authors@R: c(
-    person("Bia", "Dias", , "first.last@example.com", role = c("aut", "cre")),
-    person("Kerim", "Aydin", , "first.last@example.com", role = c("aut"))
+    person("Bia", "Dias", , "bia.dias@noaa.gov", role = c("aut", "cre"), comment=c(ORCID="0000-0001-5905-4044")),
+    person("Kerim", "Aydin", , "kerim.aydin@noaa.gov", role = c("aut"))
     )
-Description: What the package does (one paragraph).
+Description: Visualization package companion for Ecopath/Rpath. You load a Rpath object and rpathviz provides beautiful plots of your food web and simulations using ggraph and plotly. 
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,11 +20,12 @@ Imports:
     tibble,
     tidygraph,
     tidyr,
+    tidyselect,
     ggraph,
     grDevices,
     igraph,
-    colorspace,
     magrittr,
+    rlang,
     stats
 Suggests: 
     knitr,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,3 +3,4 @@
 export(rsimplot_rpathviz)
 export(webplot_rpathviz)
 importFrom(magrittr,`%>%`)
+importFrom(rlang,`%||%`)

--- a/R/rsimplot_rpathviz.R
+++ b/R/rsimplot_rpathviz.R
@@ -13,6 +13,9 @@
 #'
 #' @return An interactive plotly object
 #'
+#' @importFrom magrittr `%>%`
+#' @importFrom rlang `%||%`
+#'
 #' @section Contributors:
 #' rsim.plot function from Rpath by Kerim Aydin
 #'
@@ -23,9 +26,12 @@
 #' runObj <- rsim.scenario(rpath(REco.params), REco.params, years= 1:50)
 #' Rsim.output <- rsim.run(runObj, years= 1:50)
 #' # plot the Rsim object two default color blind friendly palettes
-#' rsimplot_rpathviz(Rsim.output, eco.name= "Anchovy Bay", spname = "all", palette= "rsim_pal_dark")
-#' rsimplot_rpathviz(Rsim.output, eco.name= "Anchovy Bay", spname = "all", palette= "rsim_pal_light")
-#' rsimplot_rpathviz(Rsim.output, eco.name= "Anchovy Bay", spname = "Foragefish2", rel_bio=FALSE, palette= "rsim_pal_light")
+#' rsimplot_rpathviz(Rsim.output, eco.name= "Anchovy Bay", spname = "all",
+#' palette= "rsim_pal_dark")
+#' rsimplot_rpathviz(Rsim.output, eco.name= "Anchovy Bay", spname = "all",
+#' palette= "rsim_pal_light")
+#' rsimplot_rpathviz(Rsim.output, eco.name= "Anchovy Bay", spname = "Foragefish2",
+#' rel_bio=FALSE, palette= "rsim_pal_light")
 #'
 #' }
 #'
@@ -86,7 +92,7 @@ rsimplot_rpathviz <- function(Rsim.output,
   val_name <- if (rel_bio) "Biomass" else "RelativeBiomass"
   df_long <- tidyr::pivot_longer(
     df,
-    cols      = all_of(data_cols),
+    cols      = tidyselect::all_of(data_cols),
     names_to  = "Species",
     values_to = val_name
   )
@@ -155,7 +161,7 @@ rsimplot_rpathviz <- function(Rsim.output,
   rsim_int_plotly <- plotly::plot_ly(
     data = df_long,
     x = ~ time,
-    y = as.formula(paste0("~", val_name)),
+    y = stats::as.formula(paste0("~", val_name)),
     color = ~ Species,
     colors = my_colors,
     type = 'scatter',

--- a/R/rsimplot_rpathviz.R
+++ b/R/rsimplot_rpathviz.R
@@ -5,10 +5,11 @@
 #'
 #'add another paragraph
 #'
-#' @param Rsim.output An object of class Rsim
-#' @param spname A character vector of species names to plot
-#' @param indplot Logical value of whether to plot a single group or multiple groups
-#' @param palette A character vector of colors to use
+#' @param Rsim.output An object of class Rsim.
+#' @param eco.name Optional name of the ecosystem.
+#' @param spname A character vector of species names to plot. If "all", all species will be plotted and rel_bio will use the default FALSE.
+#' @param rel_bio Logical value of whether to plot a single group biomass as relative or absolute value.
+#' @param palette A character vector of colors to use.
 #'
 #' @return An interactive plotly object
 #'
@@ -21,8 +22,10 @@
 #' library(Rpath)
 #' runObj <- rsim.scenario(rpath(REco.params), REco.params, years= 1:50)
 #' Rsim.output <- rsim.run(runObj, years= 1:50)
-#' # plot the Rsim object
-#' rsimplot_rpathviz(Rsim.output)
+#' # plot the Rsim object two default color blind friendly palettes
+#' rsimplot_rpathviz(Rsim.output, eco.name= "Anchovy Bay", spname = "all", palette= "rsim_pal_dark")
+#' rsimplot_rpathviz(Rsim.output, eco.name= "Anchovy Bay", spname = "all", palette= "rsim_pal_light")
+#' rsimplot_rpathviz(Rsim.output, eco.name= "Anchovy Bay", spname = "Foragefish2", rel_bio=FALSE, palette= "rsim_pal_light")
 #'
 #' }
 #'
@@ -30,17 +33,11 @@
 
 
 
-
-#library(plotly)
-#library(tidyverse)
-#library(colorspace) # default color palette, but I can simplify this later
-#library(grDevices)
-
-
 rsimplot_rpathviz <- function(Rsim.output,
+                                  eco.name = NULL,
                                   spname = "all",
-                                  indplot = FALSE,
-                                  palette = "rainbow") {
+                                  rel_bio = FALSE,
+                                  palette = "rsim_pal_dark") {
   rsim_name <- base::deparse(substitute(Rsim.output))
   mrg <- list(
     l = 50,
@@ -53,69 +50,127 @@ rsimplot_rpathviz <- function(Rsim.output,
   if ("all" %in% spname) {
     spname <- base::colnames(Rsim.output$out_Biomass)[2:ncol(Rsim.output$out_Biomass)]
   }
-  # Extract and calculate rel. B
-  if (!indplot) {
-    # Multiple functional groups
-    biomass <- Rsim.output$out_Biomass[, spname, drop = FALSE]
-    start.bio <- biomass[1, ]
-    start.bio[start.bio == 0] <- 1
-    rel.bio <- base::sweep(biomass, 2, start.bio, "/") # divide each column by its start value
+  # Setting up to calculate relative biomass or absolute biomass in case of only one species is selected
+  single_sp <- (base::length(spname) == 1)
+
+  if (single_sp && !rel_bio) {
+
+    spnum   <- base::which(Rsim.output$params$spname == spname)
+    mat     <- Rsim.output$out_Biomass[, spnum, drop = FALSE]
+    plot.bio <- mat
+    val_name <- "Biomass"
   } else {
-    # For a single functional group
-    spnum <- base::which(Rsim.output$params$spname == spname)
-    biomass <- Rsim.output$out_Biomass[, spnum]
-    rel.bio <- biomass / biomass[1]
-    rel.bio <- base::matrix(rel.bio,
-                      ncol = 1,
-                      dimnames = list(NULL, spname))
+    # relative biomass for many species or for a single species in rel_bio mode
+    mat       <- Rsim.output$out_Biomass[, spname, drop = FALSE]
+    start.val <- mat[1, ]
+    start.val[start.val == 0] <- 1
+    plot.bio  <- base::sweep(mat, 2, start.val, "/")
+    val_name  <- "RelativeBiomass"
   }
 
   # Create a time vector
-  time <- base::seq_len(nrow(rel.bio))
-  df <- base::cbind(time, as.data.frame(rel.bio))
-  df_long <- tidyr::pivot_longer(df,
-                                 cols = -time,
-                                 names_to = "Species",
-                                 values_to = "RelativeBiomass")
-  df_long$Species <- base::factor(df_long$Species, levels = spname)
-  n_species <- base::length(spname)
-  #b_palette <- colorspace::rainbow_hcl
+  time <- base::seq_len(base::nrow(plot.bio))
+  df <- base::cbind(time, base::as.data.frame(plot.bio))
 
-  if (is.character(palette) &&
-      length(palette) == 1 && exists(palette, mode = "function")) {
+  # Here is a little error msg for the user, in case they try to plot a species that is not in the output
+  data_cols <- base::setdiff(names(df), "time")
+  if (length(data_cols) == 0) {
+    stop(
+      "Hey, no species columns found to plot.\n",
+      "  * Check your `spname` argument: ",
+      paste0("'", paste(spname, collapse = "', '"), "'"),
+      " not in out_Biomass."
+    )
+  }
+
+  val_name <- if (rel_bio) "Biomass" else "RelativeBiomass"
+  df_long <- tidyr::pivot_longer(
+    df,
+    cols      = all_of(data_cols),
+    names_to  = "Species",
+    values_to = val_name
+  )
+
+  df_long$Species <- base::factor(df_long$Species, levels = spname)
+
+   n_species <- base::length(spname)
+
+  rsim_pal_dark <-  c("#EC7604", "#EF5703" ,"#D37844" ,"#C07B65" ,"#967F89", "#6C83AE" ,"#4982AF" ,"#2D7D8B", "#117867", "#166158", "#254451", "#35274A")
+  rsim_pal_light <- c("#FFAB88", "#FF9D8A", "#FFA57B", "#EFA793", "#C5AEB8", "#9DB3DF", "#82B4E2", "#71B2C1", "#64B1A0", "#68A097", "#738A97", "#807693")
+
+  if (is.character(palette) && length(palette) == 1 &&
+      palette %in% c("rsim_pal_dark", "rsim_pal_light")) {
+    pal_vec <- get(palette)
+    my_colors <- if (length(pal_vec) < n_species) {
+      grDevices::colorRampPalette(pal_vec)(n_species)
+    } else {
+      pal_vec[1:n_species]
+    }
+  } else if (base::is.character(palette) && base::length(palette) == 1 &&
+             exists(palette, mode = "function")) {
+    # named base‐R palette function
     # If the palette is pre-determined e.g. "rainbow" or "terrain.colors"
     # https://www.nceas.ucsb.edu/sites/default/files/2020-04/colorPaletteCheatsheet.pdf
-    pal_fun <- base::match.fun(palette)
-    my_colors <- pal_fun(n_species)
-  } else if (is.character(palette) && length(palette) > 1) {
+    my_colors <- base::match.fun(palette)(n_species)
+  } else if (base::is.character(palette) && base::length(palette) > 1) {
     # If you decide to give a vector of colors
-    if (length(palette) < n_species) {
+    my_colors <- if (base::length(palette) < n_species) {
       # the function will interpolate if there not enough colors
-      my_colors <- grDevices::colorRampPalette(palette)(n_species)
+      grDevices::colorRampPalette(palette)(n_species)
     } else {
-      # If enough colors or more
-      my_colors <- palette[1:n_species]
+      # If enough colors
+      palette[1:n_species]
     }
   } else {
-    my_colors <- grDevices::rainbow(n_species)
+    # Default to rsim_pal_dark if palette is not specified
+    my_colors <- if (length(rsim_pal_dark) < n_species) {
+      grDevices::colorRampPalette(rsim_pal_dark)(n_species)
+    } else {
+      rsim_pal_dark[1:n_species]
+    }
+  }
+
+
+  if (val_name == "Biomass") {
+    title_text <- sprintf(
+      "Absolute Biomass Over Time for %s in %s",
+      spname, eco.name %||% rsim_name
+    )
+  } else {
+    # relative case
+    if (single_sp && rel_bio) {
+      title_text <- sprintf(
+        "Relative Biomass Over Time for %s in %s",
+        spname, eco.name %||% rsim_name
+      )
+    } else {
+      title_text <- sprintf(
+        "Relative Biomass Over Time in %s",
+        eco.name %||% rsim_name
+      )
+    }
   }
 
   # Plotly object
   rsim_int_plotly <- plotly::plot_ly(
     data = df_long,
     x = ~ time,
-    y = ~ RelativeBiomass,
+    y = as.formula(paste0("~", val_name)),
     color = ~ Species,
     colors = my_colors,
     type = 'scatter',
     mode = 'lines'
   ) %>%
     plotly::layout(
-      title = paste("Relative Biomass Over Time:" , rsim_name),
-      xaxis = list(title = "Months"),
-      yaxis = list(title = "Relative Biomass"),
-      margin = mrg
+      title  = title_text,
+      xaxis  = list(title = "Months"),
+      yaxis  = list(
+        title      = if (val_name == "Biomass") "Biomass" else "Relative Biomass"
+      ),
+      margin = mrg,
+      legend = list(traceorder = "normal")
     )
 
   return(rsim_int_plotly)
 }
+

--- a/R/webplot_rpathviz.R
+++ b/R/webplot_rpathviz.R
@@ -51,15 +51,6 @@ webplot_rpathviz <- function(Rpath.obj,
                                  text_size= 3)
 {
 
-  # Function to scale node size based on Biomass
-  scale_value <- function(x,
-                          orig_min = min(x),
-                          orig_max = max(x),
-                          new_min = 1,
-                          new_max = 30) {
-    new_min + ((x - orig_min) / (orig_max - orig_min)) * (new_max - new_min)
-  }
-
   colors_net <- grDevices::colorRampPalette(c("#EC7604" , "#CB7A5C", "#5785C1", "#0B775E"))
 
   # Building the nodes with Rpath object.
@@ -230,4 +221,22 @@ webplot_rpathviz <- function(Rpath.obj,
     )
 
   return(p)
+}
+
+#' Function to scale node size based on Biomass
+#'
+#' @param x Numeric vector of values to be scaled.
+#' @param orig_min Minimum value of the original scale (default is minimum of x).
+#' @param orig_max Maximum value of the original scale (default is maximum of x).
+#' @param new_min Minimum value of the new scale (default is 1).
+#' @param new_max Maximum value of the new scale (default is 30).
+#'
+#' @noRd
+
+scale_value <- function(x,
+                        orig_min = min(x),
+                        orig_max = max(x),
+                        new_min = 1,
+                        new_max = 30) {
+  new_min + ((x - orig_min) / (orig_max - orig_min)) * (new_max - new_min)
 }

--- a/R/webplot_rpathviz.R
+++ b/R/webplot_rpathviz.R
@@ -38,7 +38,7 @@
 #' # Plot food web diagram with all groups labeled, including fleets. Follow the steps
 #' # 1) assign the plot to an object
 #' # 2) use ggplot2::ggsave() to save the plot for a fast visualization
-#' wp <- webplot_rpathviz(Rpath.obj, h_spacing = 3, text_size = 3)
+#' wp <- webplot_rpathviz(Rpath.obj, h_spacing = 3, text_size = 3, node_size_min = 1, node_size_max = 50)
 #' ggplot2::ggsave("figures/EBSfoodwebplot2.png", p , width= 16, height= 10)
 #'
 #'

--- a/R/webplot_rpathviz.R
+++ b/R/webplot_rpathviz.R
@@ -38,7 +38,8 @@
 #' # Plot food web diagram with all groups labeled, including fleets. Follow the steps
 #' # 1) assign the plot to an object
 #' # 2) use ggplot2::ggsave() to save the plot for a fast visualization
-#' wp <- webplot_rpathviz(Rpath.obj, h_spacing = 3, text_size = 3, node_size_min = 1, node_size_max = 50)
+#' wp <- webplot_rpathviz(Rpath.obj, h_spacing = 3, text_size = 3,
+#' node_size_min = 1, node_size_max = 50)
 #' ggplot2::ggsave("figures/EBSfoodwebplot2.png", p , width= 16, height= 10)
 #'
 #'
@@ -57,7 +58,7 @@ webplot_rpathviz <- function(Rpath.obj,
                                  groups_palette = "rpath_pal_dark",
                                  text_size= 3)
 {
-
+  Biomass <- Group <- GroupNum <- cluster <- edge_stat <- fleet_tot <- from <- from_new <- id <- index <- new_id <- node_size <- to <- to_new <- type <- width <- NULL
   #Number of groups check to determine function plot
   if (Rpath.obj$NUM_GROUPS > 20) {
     message("Your food web object has more than 20 functional groups.

--- a/R/webplot_rpathviz.R
+++ b/R/webplot_rpathviz.R
@@ -10,7 +10,10 @@
 #'  rpath object created from running \code{rpath()}.
 #' @param line.col description.
 #' @param h_spacing horizontal spacing multiplier, it spreads nodes horizontally.
+#' @param node_size_min from scale_value() Minimum value of the new scale (default is 1).
+#' @param node_size_max from scale_value() Maximum value of the new scale (default is 30).
 #' @param fleet_color single color for fleet nodes.
+#' @param groups_palette color palette for non-fleet groups. Default is a vector of colors.
 #' @param text_size size of the text labels.
 #'
 #' @return Returns a plot visualization of the food web.
@@ -18,7 +21,10 @@
 #' @importFrom magrittr `%>%`
 #'
 #' @section Contributors:
-#' webplot function from Rpath by Kerim Aydin
+#' webplot original function from Rpath by Kerim Aydin
+#'
+#' @section Plotting:
+#' Caution: For large food webs see the examples.
 #'
 #' @examples
 #' \dontrun{
@@ -27,31 +33,39 @@
 #' # Plot food web diagram with all groups labeled, including fleets
 #' webplot_rpathviz(Rpath.obj, h_spacing = 3, text_size = 3)
 #'
+#' # Read in Rpath parameter file, generate and name model object
+#' Rpath.obj <- Rpath::rpath(Rpath::Ecosense.EBS, eco.name = "Eastern Bering Sea")
+#' # Plot food web diagram with all groups labeled, including fleets. Follow the steps
+#' # 1) assign the plot to an object
+#' # 2) use ggplot2::ggsave() to save the plot for a fast visualization
+#' wp <- webplot_rpathviz(Rpath.obj, h_spacing = 3, text_size = 3)
+#' ggplot2::ggsave("figures/EBSfoodwebplot2.png", p , width= 16, height= 10)
+#'
+#'
 #' }
 #'
 #' @export
 
- # Load required libraries
- # library(tidyverse)
- # library(tidygraph)
- # library(ggraph)
- # library(purrr)
- # library(igraph)
-
- # Define a color palette generator for non-fleet clusters
- #colors_net <- colorRampPalette(c("#3A9AB2", "#6FB2C1", "#91BAB6", "#A5C2A3",
- #                                 "#BDC881", "#DCCB4E", "#E3B710", "#E79805",
- #                                 "#EC7A05", "#EF5703"))
 
 webplot_rpathviz <- function(Rpath.obj,
                                  eco.name = attr(Rpath.obj, "eco.name"),
                                  line.col = "grey",
                                  h_spacing = 3,
+                                 node_size_min = 1,
+                                 node_size_max = 30,
                                  fleet_color = "#B40F20", # single color for fleet nodes
+                                 groups_palette = c("#EC7604", "#CB7A5C", "#5785C1", "#0B775E"),
                                  text_size= 3)
 {
 
-  colors_net <- grDevices::colorRampPalette(c("#EC7604" , "#CB7A5C", "#5785C1", "#0B775E"))
+  #Number of groups check to determine function plot
+  if (Rpath.obj$NUM_GROUPS > 20) {
+    message("Your food web object has more than 20 functional groups.
+    \nPlotting to the RStudio window will take a while, please be patient...
+    Refer to the examples for large food webs.")
+  }
+
+  colors_net <- grDevices::colorRampPalette(groups_palette)
 
   # Building the nodes with Rpath object.
   nodes <- tibble::tibble(
@@ -76,7 +90,7 @@ webplot_rpathviz <- function(Rpath.obj,
 
   # Compute node size based on Biomass.
   nodes <- nodes %>%
-    dplyr::mutate(node_size = scale_value(Biomass, new_min = 10, new_max = 50))
+    dplyr::mutate(node_size = scale_value(Biomass, node_size_min = 10, node_size_max = 30))
 
   # Build the edge list using the original node IDs.
   allowed_ids <- nodes$id
@@ -175,6 +189,7 @@ webplot_rpathviz <- function(Rpath.obj,
 
   ggraph::set_graph_style(plot_margin = ggplot2::margin(30, 30, 30, 30))
   jitter <- ggplot2::position_jitter(width = 0.1, height = 0.1)
+
 #browser() #for checks
   # Build the ggraph plot
   p <- ggraph::ggraph(lay) +
@@ -183,7 +198,7 @@ webplot_rpathviz <- function(Rpath.obj,
                    color = ggplot2::after_stat(index)),
                    lineend = "round",
                    alpha = 0.30) +
-    ggraph::scale_edge_colour_gradient(low = "#ffd06f", high = "#aadce0", guide = "colorbar") +
+    ggraph::scale_edge_colour_gradient(low = "#ffd06f", high = "#aadce0", guide = "legend") +
     ggraph::geom_edge_loop(ggplot2::aes(edge_width = width, color = ggplot2::after_stat(index)),
                    alpha = 0.85,
                    lineend = "round") +
@@ -228,15 +243,15 @@ webplot_rpathviz <- function(Rpath.obj,
 #' @param x Numeric vector of values to be scaled.
 #' @param orig_min Minimum value of the original scale (default is minimum of x).
 #' @param orig_max Maximum value of the original scale (default is maximum of x).
-#' @param new_min Minimum value of the new scale (default is 1).
-#' @param new_max Maximum value of the new scale (default is 30).
+#' @param node_size_min Minimum value of the new scale (default is 1).
+#' @param node_size_max Maximum value of the new scale (default is 30).
 #'
 #' @noRd
 
 scale_value <- function(x,
                         orig_min = min(x),
                         orig_max = max(x),
-                        new_min = 1,
-                        new_max = 30) {
-  new_min + ((x - orig_min) / (orig_max - orig_min)) * (new_max - new_min)
+                        node_size_min = 1,
+                        node_size_max = 30) {
+  node_size_min + ((x - orig_min) / (orig_max - orig_min)) * (node_size_max - node_size_min)
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rpath_viz
+# rpathviz
 
 <!-- badges: start -->
   [![R-CMD-check](https://github.com/biadias/rpathviz/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/biadias/rpathviz/actions/workflows/R-CMD-check.yaml)

--- a/man/rsimplot_rpathviz.Rd
+++ b/man/rsimplot_rpathviz.Rd
@@ -6,19 +6,22 @@
 \usage{
 rsimplot_rpathviz(
   Rsim.output,
+  eco.name = NULL,
   spname = "all",
-  indplot = FALSE,
-  palette = "rainbow"
+  rel_bio = FALSE,
+  palette = "rsim_pal_dark"
 )
 }
 \arguments{
-\item{Rsim.output}{An object of class Rsim}
+\item{Rsim.output}{An object of class Rsim.}
 
-\item{spname}{A character vector of species names to plot}
+\item{eco.name}{Optional name of the ecosystem.}
 
-\item{indplot}{Logical value of whether to plot a single group or multiple groups}
+\item{spname}{A character vector of species names to plot. If "all", all species will be plotted and rel_bio will use the default FALSE.}
 
-\item{palette}{A character vector of colors to use}
+\item{rel_bio}{Logical value of whether to plot a single group biomass as relative or absolute value.}
+
+\item{palette}{A character vector of colors to use.}
 }
 \value{
 An interactive plotly object
@@ -39,8 +42,10 @@ rsim.plot function from Rpath by Kerim Aydin
 library(Rpath)
 runObj <- rsim.scenario(rpath(REco.params), REco.params, years= 1:50)
 Rsim.output <- rsim.run(runObj, years= 1:50)
-# plot the Rsim object
-rsimplot_rpathviz(Rsim.output)
+# plot the Rsim object two default color blind friendly palettes
+rsimplot_rpathviz(Rsim.output, eco.name= "Anchovy Bay", spname = "all", palette= "rsim_pal_dark")
+rsimplot_rpathviz(Rsim.output, eco.name= "Anchovy Bay", spname = "all", palette= "rsim_pal_light")
+rsimplot_rpathviz(Rsim.output, eco.name= "Anchovy Bay", spname = "Foragefish2", rel_bio=FALSE, palette= "rsim_pal_light")
 
 }
 

--- a/man/rsimplot_rpathviz.Rd
+++ b/man/rsimplot_rpathviz.Rd
@@ -43,9 +43,12 @@ library(Rpath)
 runObj <- rsim.scenario(rpath(REco.params), REco.params, years= 1:50)
 Rsim.output <- rsim.run(runObj, years= 1:50)
 # plot the Rsim object two default color blind friendly palettes
-rsimplot_rpathviz(Rsim.output, eco.name= "Anchovy Bay", spname = "all", palette= "rsim_pal_dark")
-rsimplot_rpathviz(Rsim.output, eco.name= "Anchovy Bay", spname = "all", palette= "rsim_pal_light")
-rsimplot_rpathviz(Rsim.output, eco.name= "Anchovy Bay", spname = "Foragefish2", rel_bio=FALSE, palette= "rsim_pal_light")
+rsimplot_rpathviz(Rsim.output, eco.name= "Anchovy Bay", spname = "all",
+palette= "rsim_pal_dark")
+rsimplot_rpathviz(Rsim.output, eco.name= "Anchovy Bay", spname = "all",
+palette= "rsim_pal_light")
+rsimplot_rpathviz(Rsim.output, eco.name= "Anchovy Bay", spname = "Foragefish2",
+rel_bio=FALSE, palette= "rsim_pal_light")
 
 }
 

--- a/man/webplot_rpathviz.Rd
+++ b/man/webplot_rpathviz.Rd
@@ -32,7 +32,7 @@ rpath object created from running \code{rpath()}.}
 
 \item{fleet_color}{single color for fleet nodes.}
 
-\item{groups_palette}{color palette for non-fleet groups. Default is a vector of colors.}
+\item{groups_palette}{color palette for non-fleet groups. Two palette options rpath_pal_dark and rpath_pal_light.}
 
 \item{text_size}{size of the text labels.}
 }
@@ -66,7 +66,8 @@ Rpath.obj <- Rpath::rpath(Rpath::Ecosense.EBS, eco.name = "Eastern Bering Sea")
 # Plot food web diagram with all groups labeled, including fleets. Follow the steps
 # 1) assign the plot to an object
 # 2) use ggplot2::ggsave() to save the plot for a fast visualization
-wp <- webplot_rpathviz(Rpath.obj, h_spacing = 3, text_size = 3, node_size_min = 1, node_size_max = 50)
+wp <- webplot_rpathviz(Rpath.obj, h_spacing = 3, text_size = 3,
+node_size_min = 1, node_size_max = 50)
 ggplot2::ggsave("figures/EBSfoodwebplot2.png", p , width= 16, height= 10)
 
 

--- a/man/webplot_rpathviz.Rd
+++ b/man/webplot_rpathviz.Rd
@@ -9,7 +9,10 @@ webplot_rpathviz(
   eco.name = attr(Rpath.obj, "eco.name"),
   line.col = "grey",
   h_spacing = 3,
+  node_size_min = 1,
+  node_size_max = 30,
   fleet_color = "#B40F20",
+  groups_palette = c("#EC7604", "#CB7A5C", "#5785C1", "#0B775E"),
   text_size = 3
 )
 }
@@ -23,7 +26,13 @@ rpath object created from running \code{rpath()}.}
 
 \item{h_spacing}{horizontal spacing multiplier, it spreads nodes horizontally.}
 
+\item{node_size_min}{from scale_value() Minimum value of the new scale (default is 1).}
+
+\item{node_size_max}{from scale_value() Maximum value of the new scale (default is 30).}
+
 \item{fleet_color}{single color for fleet nodes.}
+
+\item{groups_palette}{color palette for non-fleet groups. Default is a vector of colors.}
 
 \item{text_size}{size of the text labels.}
 }
@@ -40,12 +49,26 @@ add another paragraph
 webplot function from Rpath by Kerim Aydin
 }
 
+\section{Plotting}{
+
+Caution: For large food webs see the examples.
+}
+
 \examples{
 \dontrun{
 # Read in Rpath parameter file, generate and name model object
 Rpath.obj <- Rpath::rpath(Rpath::AB.params, eco.name = "Anchovy Bay")
 # Plot food web diagram with all groups labeled, including fleets
 webplot_rpathviz(Rpath.obj, h_spacing = 3, text_size = 3)
+
+# Read in Rpath parameter file, generate and name model object
+Rpath.obj <- Rpath::rpath(Rpath::Ecosense.EBS, eco.name = "Eastern Bering Sea")
+# Plot food web diagram with all groups labeled, including fleets. Follow the steps
+# 1) assign the plot to an object
+# 2) use ggplot2::ggsave() to save the plot for a fast visualization
+wp <- webplot_rpathviz(Rpath.obj, h_spacing = 3, text_size = 3)
+ggplot2::ggsave("figures/EBSfoodwebplot2.png", p , width= 16, height= 10)
+
 
 }
 

--- a/man/webplot_rpathviz.Rd
+++ b/man/webplot_rpathviz.Rd
@@ -46,7 +46,7 @@ add another paragraph
 }
 \section{Contributors}{
 
-webplot function from Rpath by Kerim Aydin
+webplot original function from Rpath by Kerim Aydin
 }
 
 \section{Plotting}{
@@ -66,7 +66,7 @@ Rpath.obj <- Rpath::rpath(Rpath::Ecosense.EBS, eco.name = "Eastern Bering Sea")
 # Plot food web diagram with all groups labeled, including fleets. Follow the steps
 # 1) assign the plot to an object
 # 2) use ggplot2::ggsave() to save the plot for a fast visualization
-wp <- webplot_rpathviz(Rpath.obj, h_spacing = 3, text_size = 3)
+wp <- webplot_rpathviz(Rpath.obj, h_spacing = 3, text_size = 3, node_size_min = 1, node_size_max = 50)
 ggplot2::ggsave("figures/EBSfoodwebplot2.png", p , width= 16, height= 10)
 
 

--- a/man/webplot_rpathviz.Rd
+++ b/man/webplot_rpathviz.Rd
@@ -12,7 +12,7 @@ webplot_rpathviz(
   node_size_min = 1,
   node_size_max = 30,
   fleet_color = "#B40F20",
-  groups_palette = c("#EC7604", "#CB7A5C", "#5785C1", "#0B775E"),
+  groups_palette = "rpath_pal_dark",
   text_size = 3
 )
 }


### PR DESCRIPTION
Edits to rsimplot_rpathviz() to add more flexibility to the user.
1) Two default colorblind friendly palettes designed by B. Dias.
2) addition of the rel_bio parameter to provide the user the option to plot absolute or relative values for a single species plot.
3) addition eco.name option, the default will be whatever name was given to the rsim.run(runObj) object.

Edits to webplot_rpathviz() to add a similar color scheme to the one for rsimplot_rpathviz()
1) Addition of the two rpath palettes (rpath_pal_dark and rpath_pal_light) and the make_pal() function. That will deal with the user palette choice.